### PR TITLE
Fix: search index gating + prebuilt asset + CI guardrails

### DIFF
--- a/.github/issues_seed.json
+++ b/.github/issues_seed.json
@@ -47,5 +47,12 @@
       "body": "Audit heavy UI trees. Replace broad Consumers with targeted Selectors; add const constructors; avoid state changes in build. Document hotspots in the code and add guidance.",
       "assignees": []
     }
+    ,
+    {
+      "title": "[Perf] Defer search index initialization until Search tab is opened",
+      "labels": ["perf", "high-priority"],
+      "body": "Fully defer search index ensure/build until the user interacts with the Search tab (open or first non-empty query). Remove any startup-time ensure calls. Validate with DevTools that no index parsing/build happens before Search is used, and verify cold start skipped frames drop. Add a small integration test that asserts index manager is not built on app start.",
+      "assignees": []
+    }
   ]
 }

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,56 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main, master, develop, fix/**, feature/** ]
+  pull_request:
+    branches: [ main, master, develop, fix/**, feature/** ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            **/build
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Pub get
+        run: flutter pub get
+
+      - name: Build prebuilt search index
+        run: dart run tool/build_search_index.dart
+
+      - name: Validate assets
+        run: dart run tool/validate_assets.dart
+
+      - name: Analyze (non-fatal)
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Run tests
+        run: flutter test --reporter expanded --coverage --no-pub
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info

--- a/.github/workflows/seed-issues.yml
+++ b/.github/workflows/seed-issues.yml
@@ -2,6 +2,15 @@ name: Seed Issues
 
 on:
   workflow_dispatch:
+    inputs:
+      fail_on_noop:
+        description: "Fail the job if nothing new is created"
+        required: false
+        default: "false"
+      dry_run:
+        description: "Don't create anything, just print what would be done"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -24,6 +33,9 @@ jobs:
             const seedPath = path.join(process.env.GITHUB_WORKSPACE, '.github', 'issues_seed.json');
             const seed = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
 
+            const failOnNoop = (core.getInput('fail_on_noop') || 'false').toLowerCase() === 'true';
+            const dryRun = (core.getInput('dry_run') || 'false').toLowerCase() === 'true';
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
@@ -37,6 +49,8 @@ jobs:
             let labelsCreated = 0;
             let issuesCreated = 0;
             let milestoneCreated = false;
+            let labelsPlanned = 0;
+            let issuesPlanned = 0;
 
             // Ensure labels exist
             const desiredLabels = seed.labels || [];
@@ -45,9 +59,14 @@ jobs:
 
       for (const l of desiredLabels) {
               if (!existingLabelNames.has(l.name)) {
-                core.info(`Creating missing label: ${l.name}`);
-        await github.rest.issues.createLabel({ owner, repo, name: l.name, color: l.color || 'cccccc', description: l.description || '' });
-        labelsCreated++;
+                if (dryRun) {
+                  core.info(`[dry-run] Would create label: ${l.name}`);
+                  labelsPlanned++;
+                } else {
+                  core.info(`Creating missing label: ${l.name}`);
+                  await github.rest.issues.createLabel({ owner, repo, name: l.name, color: l.color || 'cccccc', description: l.description || '' });
+                  labelsCreated++;
+                }
               }
             }
 
@@ -60,10 +79,15 @@ jobs:
                 milestoneNumber = found.number;
                 core.info(`Using existing milestone: ${found.title} (#${found.number})`);
               } else {
-                const created = await github.rest.issues.createMilestone({ owner, repo, title: seed.milestone.title, description: seed.milestone.description || '' });
-                milestoneNumber = created.data.number;
-                milestoneCreated = true;
-                core.info(`Created milestone: ${seed.milestone.title} (#${milestoneNumber})`);
+                if (dryRun) {
+                  core.info(`[dry-run] Would create milestone: ${seed.milestone.title}`);
+                  milestoneCreated = true; // mark planned for summary
+                } else {
+                  const created = await github.rest.issues.createMilestone({ owner, repo, title: seed.milestone.title, description: seed.milestone.description || '' });
+                  milestoneNumber = created.data.number;
+                  milestoneCreated = true;
+                  core.info(`Created milestone: ${seed.milestone.title} (#${milestoneNumber})`);
+                }
               }
             }
 
@@ -78,29 +102,40 @@ jobs:
               }
 
               const labels = issue.labels || [];
-              const res = await github.rest.issues.create({
-                owner,
-                repo,
-                title: issue.title,
-                body: issue.body,
-                labels,
-                milestone: milestoneNumber,
-                assignees: issue.assignees || [],
-              });
-              issuesCreated++;
-              core.info(`Created issue #${res.data.number}: ${issue.title}`);
+              if (dryRun) {
+                core.info(`[dry-run] Would create issue: ${issue.title}`);
+                issuesPlanned++;
+              } else {
+                const res = await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title: issue.title,
+                  body: issue.body,
+                  labels,
+                  milestone: milestoneNumber,
+                  assignees: issue.assignees || [],
+                });
+                issuesCreated++;
+                core.info(`Created issue #${res.data.number}: ${issue.title}`);
+              }
             }
 
             // Summarize
             await core.summary
               .addHeading('Seed Issues Summary')
               .addList([
-                `Labels created: ${labelsCreated}`,
-                `Milestone created: ${milestoneCreated}`,
-                `Issues created: ${issuesCreated}`,
+                `Labels ${dryRun ? 'planned' : 'created'}: ${dryRun ? labelsPlanned : labelsCreated}`,
+                `Milestone ${dryRun ? 'planned' : 'created'}: ${milestoneCreated}`,
+                `Issues ${dryRun ? 'planned' : 'created'}: ${dryRun ? issuesPlanned : issuesCreated}`,
               ])
               .write();
 
-            if (labelsCreated === 0 && !milestoneCreated && issuesCreated === 0) {
-              core.setFailed('Nothing was created. Likely causes: missing permissions, Issues disabled, or items already existed.');
+            const nothingChanged = (labelsCreated === 0 && !milestoneCreated && issuesCreated === 0);
+            if (nothingChanged) {
+              const msg = 'Nothing to create. Likely items already exist or Issues are disabled.';
+              if (dryRun || !failOnNoop) {
+                core.notice(msg);
+              } else {
+                core.setFailed(msg);
+              }
             }

--- a/DATA_ARCHITECTURE.md
+++ b/DATA_ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# DATA_ARCHITECTURE: Post‑Mortem + Udhëzues Parandalues
+
+Ky dokument përmbledh analizën e shkaqeve rrënjësore (post‑mortem) dhe përshkruan arkitekturën e rekomanduar të të dhënave për të parandaluar regresione në të ardhmen në aplikacionin Flutter “Kurani Fisnik”.
+
+
+## Pjesa 1 — Analiza Post‑Mortem (Root Cause Analysis)
+
+### 1.1 Problemi i unifikuar: konflikt “Eager” vs “Lazy” loading
+- Qëllimi: kërkimi funksional që në hapjen e aplikacionit kërkon të dhëna të plota (eager), ndërsa nisja e shpejtë kërkon ngarkim minimal (lazy).
+- Anti‑modeli: thirrja e metodave “të rënda” në start (p.sh. `getAllSurahs()` ose ngarkimi/hidratimi i plotë i indeksit/`verseCache`) bllokon thread‑in kryesor, çon në ngrirje 5–9 sekonda dhe “Skipped frames”.
+- Ndërlidhja: kur e shmangim ngrirjen me “lazy”, kërkimi mund të mos ketë të dhëna të mjaftueshme në memorie; kur e bëjmë kërkimin të menjëhershëm me “eager”, kthehet ngrirja. Zgjidhja është një strategji hibride e kontrolluar: meta‑t në start, indeks në sfond/kur kërkohet, dhe hidratim “on‑demand”.
+
+### 1.2 Pse përkthimi mungon në pamjen e leximit?
+- Hipoteza e verifikuar: rrjedha e leximit përdor një shteg “lazy” që ngarkon vetëm `SurahMeta` dhe vargjet bazë, por harron hapin e dytë të pasurimit (enrichment) me përkthimin/transliterimin e zgjedhur.
+- Pse shfaqet në rezultatet e kërkimit? Kërkimi, kur ngarkohet në mënyrë “eager”, ka një `verseCache` me të dhëna të plota ose ka “raw verse” në memorie dhe i hidraton vetëm për rezultatet. Pra, rezultati i kërkimit shfaq përkthimin, por pamja e leximit (që ndjek një rrugë tjetër) nuk bën enrichment para `notifyListeners()`.
+- Zgjidhja: në `QuranProvider.loadSurah(surahId)`, pasi merren vargjet bazë (`repository.getVersesForSurah(surahId)`), kryhet enrichment me përkthimin/transliterimin aktiv dhe vetëm pastaj thirret `notifyListeners()`. Kjo duhet të jetë e detyrueshme, jo opsionale.
+
+### 1.3 Mësimet e nxjerra
+- Mbani një strategji të vetme: “Lazy by default” + ngarkime të kontrolluara në sfond, jo rrugë të dyfishta (një “lazy”, një “eager”) brenda të njëjtit Provider.
+- Mos bllokoni thread‑in kryesor me I/O ose JSON masiv; përdorni `compute`/izolate për parsing dhe ndërtim indeksi.
+- Kërkimi ka nevoja globale (indeks), Leximi ka nevoja lokale (surah e hapur). Izoloni përgjegjësitë dhe mos ndërthurni rrjedhat.
+- Stabilizoni instancat e provider‑ëve (mos rindërtoni shpesh) që cache/indekset të mos humbasin.
+
+
+## Pjesa 2 — Arkitektura e të Dhënave (Udhëzues Parandalues)
+
+### 2.1 Filozofia kryesore: “Lazy by default”
+- Asnjëherë mos ngarko të gjithë Kuranin, përkthimet apo `verseCache` në start.
+- Ruhen vetëm meta‑t në memorie në start; ngarkesat e tjera kryhen on‑demand ose në sfond.
+
+### 2.2 Startup Flow (nisja e aplikacionit)
+1. UI minimale shfaqet sa më shpejt (splash/landing e lehtë).
+2. `QuranProvider` thërret vetëm `getSurahList()` për të marrë `SurahMeta` (id, emër, ajete, etj.).
+3. `SurahListWidget` ndërtohet nga këto meta; asnjë varg i plotë nuk hidratohet.
+4. Punët e rënda (p.sh. ngarkimi i `search_index.json`, verifikimi i snapshot‑it) fillojnë në sfond pas frame‑it të parë ose në hapjen e tabit të Kërkimit. JSON parsing/ndërtimi i indeksit të bëhet me `compute`/izolate.
+
+### 2.3 Reader View Flow (hapja e një sureje)
+1. Përdoruesi zgjedh një sure → `QuranProvider.loadSurah(surahId)`.
+2. `QuranRepository.getVersesForSurah(surahId)` kthen vargjet bazë (pa i pasuruar globalisht cache‑t).
+3. Hapi kritik: kryhet enrichment i vargjeve me përkthimin/transliterimin aktualisht të zgjedhur (p.sh. sq_*, transliterimet). Ky hap mund të përdorë një cache të vogël per‑surah dhe/ose parsing në izolat nëse skedari është i madh.
+4. Vetëm pas përfundimit të enrichment thirret `notifyListeners()` që UI të ketë të dhëna të plota. Prefetch i lehtë për 1 sure para/pas mund të lejohet, por gjithmonë në sfond.
+
+### 2.4 Search Flow (strategji hibride)
+- Indeksi kryesor (statik):
+  - Ngarkohet nga `assets/data/search_index.json` ose nga snapshot i lokalt në mënyrë asinkrone. Kjo ndodh në sfond pas nisjes ose në hapjen e parë të tabit të Kërkimit. Kurrë mos e blloko nisjen.
+  - Parsing/validimi në izolat; mos hidrato vargje objekt‑orientuar në masë—ruaj “raw verse” (harta) dhe hidrato vetëm për rezultatet e shfaqura.
+- `verseCache` (dinamik):
+  - Mos e mbush kurrë në tërësi në start. Hidrato vetëm kur:
+    - përdoruesi hap një sure (flow i leximit), ose
+    - kërkimi kthen rezultate që duhen shfaqur.
+- Ekzekutimi i kërkimit:
+  - Gating mbi indeksin e ngarkuar; përdor “raw verse” për normalizim/ranking; hidrato objekte vetëm për rreshtat që shfaqen.
+  - Përditësimet e progresit dhe rimbërthimi i UI duhet të jenë të deboncuara/throttled për të shmangur “rebuild storms”.
+
+### 2.5 Rregullat e Arta (Anti‑modelet për t’u shmangur)
+- MOS thirr `getAllSurahs()` (ose ekuivalente) në startup ose në constructor të Provider‑it.
+- MOS bëj I/O sinkron, JSON parsing masiv, ose ndërtim indeksi në thread‑in kryesor. Përdor `compute` ose izolate.
+- ÇDO Provider të jetë “lazy”: asnjë punë e rëndë në konstruktor; përdorni metoda `ensure*()` që nisin punë në sfond kur kërkohet.
+- MOS hidrato masivisht `Verse` në memorie. Ruaj “raw verse” dhe hidrato “on‑demand”.
+
+### 2.6 Stabiliteti i Provider‑ëve dhe versionimi i të dhënave
+- Mos rikrijo provider‑ët pa nevojë; përdor `ProxyProvider` me `update` që ruan instancën ekzistuese kur është e mundur.
+- Snapshot‑et dhe `search_index.json` të kenë `version` dhe `dataVersion`. Kur ndryshon korpusi (p.sh. skedarë në `assets/data/`), rrit `dataVersion` për të invaliduar cache‑t.
+
+### 2.7 Observabiliteti dhe verifikimi
+- Telemetri e lehtë: kohë nisjeje, kohë ngarkimi indeksi (sfond), numri i vargjeve të hidratuara në UI.
+- Lint/Analyzer: pa punë të rënda në konstruktorë të provider‑ëve; mos përdor `initState` për I/O pa `postFrame`/deferim.
+- Teste gardiane (smoke + unit):
+  - Startup: “0 Verse të hidratuara” pas kornizës së parë; vetëm meta‑t në memorie.
+  - Reader: hap një sure → përkthimi shfaqet; enrichment kryhet përpara `notifyListeners()`.
+  - Search: nëse indeksi nuk është gati, nis ngarkimin në sfond; kërkimet pasuese japin rezultate; nuk ka crash kur ndërrohen përkthimet.
+
+### 2.8 “Playbook” i shpejtë për regresionet
+- Nëse shfaqen ngrirje në start: kontrollo për thirrje “të rënda” në startup (I/O, JSON parsing, hidratim masiv) dhe zhvendosi në izolat/sfond.
+- Nëse mungon përkthimi në lexim: verifiko që `loadSurah()` bën enrichment para `notifyListeners()` dhe që përkthimi i zgjedhur po merret nga repo.
+- Nëse kërkimi kthen “No results”: sigurohu që indeksi/snapshot është ngarkuar (ose niset ngarkimi) dhe se provider‑i nuk është rikrijuar duke humbur cache‑t.
+
+
+## Shtojcë — Kontrata minimale e moduleve
+- `QuranRepository`
+  - Input: id e surës
+  - Output: meta ose vargje bazë; funksione për enrichment (përkthim/transliterim) që mund të punojnë në izolat.
+- `QuranProvider`
+  - Startup: `getSurahList()` (meta vetëm)
+  - Reader: `loadSurah(surahId)` → enrichment → `notifyListeners()`
+  - Search: `ensureSearchIndexReady()` që nis ngarkimin në sfond; `search(query)` që përdor indeksin dhe hidratonin “on‑demand”.
+- `SearchIndexManager`
+  - Ngarkon indeks/snapshot në sfond; ruan “raw verse”; hidraton vetëm për rezultatet; shmang “rebuild storms”.
+
+---
+
+Ky dokument është bazë referimi. Ruajeni të azhurnuar pas çdo ndryshimi në rrjedhat e të dhënave, politikën e caching‑ut ose formatin e asset‑eve.
+
+## Historia e Regresioneve dhe Parandalimi
+
+- Gusht 2025 — Regresion në Kërkim: Kërkimi dështoi sepse `assets/data/search_index.json` ishte bosh. Ky problem shfaqej me `invSize=0` në log dhe asnjë rezultat.
+  - Zgjidhja teknike: rikrijim i asetit me `tool/build_search_index.dart` dhe ngarkim i detyruar në `SearchWidget.initState` përmes `ensureSearchIndexReady()` që përdor prebuilt/snapshot.
+  - Gardianët e rinj:
+    - CI workflow gjeneron dhe validon indeksin (`tool/validate_assets.dart`) përpara analizës/testeve; dështimi i validimit ndalon PR‑in.
+    - Test i thjeshtë `test/asset_guard_test.dart` verifikon që `search_index.json` ekziston dhe ka një `index` jo‑bosh.
+  - Qëllimi: të parandalohen përsëritje të të njëjtit regresion dhe të garantohet që kërkimi të ketë gjithmonë të dhëna të vlefshme.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kurani Fisnik - Flutter App
 
+[![Flutter CI](https://github.com/gentianlloshi/kuranifisnikapp/actions/workflows/flutter-ci.yml/badge.svg)](https://github.com/gentianlloshi/kuranifisnikapp/actions/workflows/flutter-ci.yml)
+
 Aplikacion Flutter për leximin dhe studimin e Kuranit Fisnik në gjuhën shqipe.
 
 ## Përshkrimi
@@ -193,6 +195,22 @@ Për të kontribuar në projekt:
 3. Commit ndryshimet (`git commit -m \'Add some AmazingFeature\'`) 
 4. Push në branch (`git push origin feature/AmazingFeature`)
 5. Hapni një Pull Request
+
+### Contributing – Checks & Workflows
+
+- CI: Çdo PR/push ekzekuton:
+   - `flutter analyze --no-fatal-infos --no-fatal-warnings`
+   - `flutter test --coverage`
+   - Statusi i CI tregohet nga badge më sipër. Coverage ngarkohet si artifact (lcov.info).
+- Seed Issues: Workflow “Seed Issues” krijon labels/milestone/issues nga `.github/issues_seed.json`.
+   - Mund të ekzekutohet me `dry_run=true` për verifikim.
+   - `fail_on_noop=false` (default) nuk dështojnë kur s’ka asgjë të re për t’u krijuar.
+
+Rregulla PR:
+- Ruani startup-in “lazy-by-default” (pa Verse të hidratuara në cold start).
+- Shmangni punë të rënda në thread-in kryesor; preferoni `compute`/isolate.
+- Për kërkim: mos nisni `ensureBuilt()` në start; përdorni incremental build kur hapet Search.
+- Shtoni teste për rrjedhat e reja dhe azhurnoni `issues_seed.json` kur krijoni epics.
 
 ## Licenca
 

--- a/lib/domain/entities/word_by_word.dart
+++ b/lib/domain/entities/word_by_word.dart
@@ -15,11 +15,17 @@ class WordByWordVerse {
   });
 
   factory WordByWordVerse.fromJson(Map<String, dynamic> json) {
+    final verseNum = (json['verse'] as num?)?.toInt() ?? int.tryParse('${json['verse']}') ?? 0;
+    final rawWords = (json['words'] as List?) ?? const [];
+    final words = rawWords.map((e) {
+      if (e is Map) {
+        return WordData.fromJson(Map<String, dynamic>.from(e as Map));
+      }
+      return WordData.fromJson(e as Map<String, dynamic>);
+    }).toList();
     return WordByWordVerse(
-      verseNumber: json['verse'] as int,
-      words: (json['words'] as List<dynamic>)
-          .map((e) => WordData.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      verseNumber: verseNum,
+      words: words,
     );
   }
 
@@ -53,12 +59,17 @@ class WordData {
   });
 
   factory WordData.fromJson(Map<String, dynamic> json) {
+    int _toInt(dynamic v) {
+      if (v is int) return v;
+      if (v is num) return v.toInt();
+      return int.tryParse(v?.toString() ?? '') ?? 0;
+    }
     return WordData(
-      arabic: json['arabic'] as String,
-      translation: json['translation'] as String,
-      transliteration: json['transliteration'] as String,
-      charStart: json['char_start'] as int,
-      charEnd: json['char_end'] as int,
+      arabic: (json['arabic'] ?? json['text'] ?? '').toString(),
+      translation: (json['translation'] ?? '').toString(),
+      transliteration: (json['transliteration'] ?? '').toString(),
+      charStart: _toInt(json['char_start'] ?? json['start'] ?? 0),
+      charEnd: _toInt(json['char_end'] ?? json['end'] ?? 0),
     );
   }
 
@@ -86,11 +97,17 @@ class TimestampData {
   });
 
   factory TimestampData.fromJson(Map<String, dynamic> json) {
+    final verseNum = (json['verse'] as num?)?.toInt() ?? int.tryParse('${json['verse']}') ?? 0;
+    final raw = (json['words'] as List?) ?? const [];
+    final ts = raw.map((e) {
+      if (e is Map) {
+        return WordTimestamp.fromJson(Map<String, dynamic>.from(e as Map));
+      }
+      return WordTimestamp.fromJson(e as Map<String, dynamic>);
+    }).toList();
     return TimestampData(
-      verseNumber: json['verse'] as int,
-      wordTimestamps: (json['words'] as List<dynamic>)
-          .map((e) => WordTimestamp.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      verseNumber: verseNum,
+      wordTimestamps: ts,
     );
   }
 
@@ -115,9 +132,14 @@ class WordTimestamp {
   });
 
   factory WordTimestamp.fromJson(Map<String, dynamic> json) {
+    int _toInt(dynamic v) {
+      if (v is int) return v;
+      if (v is num) return v.toInt();
+      return int.tryParse(v?.toString() ?? '') ?? 0;
+    }
     return WordTimestamp(
-      start: json['start'] as int,
-      end: json['end'] as int,
+      start: _toInt(json['start']),
+      end: _toInt(json['end']),
     );
   }
 

--- a/lib/domain/repositories/quran_repository.dart
+++ b/lib/domain/repositories/quran_repository.dart
@@ -20,6 +20,9 @@ abstract class QuranRepository {
   Future<void> ensureSurahTransliteration(int surahNumber);
   bool isSurahFullyEnriched(int surahNumber);
   Map<String,double> translationCoverageByKey();
+  // Hint repository which translation key should be preferred when merging
+  // translations in getSurahVerses. This does not load data by itself.
+  void setPreferredTranslationKey(String translationKey);
   // Reactive streams (PERF-2) for UI to subscribe to coverage changes
   Stream<double> get enrichmentCoverageStream; // emits 0..1 when enrichment coverage changes
   // Optional: translation coverage per key aggregate (emit map for simplicity)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,20 +234,22 @@ class KuraniFisnikApp extends StatelessWidget {
           create: (ctx) => AppStateProvider(getSettingsUseCase: Provider.of<GetSettingsUseCase>(ctx, listen: false), saveSettingsUseCase: Provider.of<SaveSettingsUseCase>(ctx, listen: false)),
           update: (_, getSettingsUseCase, saveSettingsUseCase, previous) => previous ?? AppStateProvider(getSettingsUseCase: getSettingsUseCase, saveSettingsUseCase: saveSettingsUseCase),
         ),
-        ChangeNotifierProxyProvider5<GetSurahsUseCase, GetSurahsArabicOnlyUseCase, SearchVersesUseCase, get_verses.GetSurahVersesUseCase, QuranRepositoryImpl, QuranProvider>(
+        ChangeNotifierProxyProvider6<GetSurahsUseCase, GetSurahsArabicOnlyUseCase, SearchVersesUseCase, get_verses.GetSurahVersesUseCase, QuranRepositoryImpl, AppStateProvider, QuranProvider>(
           create: (ctx) => QuranProvider(
             getSurahsUseCase: Provider.of<GetSurahsUseCase>(ctx, listen:false),
             getSurahsArabicOnlyUseCase: Provider.of<GetSurahsArabicOnlyUseCase>(ctx, listen:false),
             searchVersesUseCase: Provider.of<SearchVersesUseCase>(ctx, listen:false),
             getSurahVersesUseCase: Provider.of<get_verses.GetSurahVersesUseCase>(ctx, listen:false),
             quranRepository: Provider.of<QuranRepositoryImpl>(ctx, listen:false),
+            appStateProvider: Provider.of<AppStateProvider>(ctx, listen:false),
           ),
-          update: (ctx, getSurahsUseCase, getSurahsArabicOnlyUseCase, searchVersesUseCase, getSurahVersesUseCase, repo, previous) => previous ?? QuranProvider(
+          update: (ctx, getSurahsUseCase, getSurahsArabicOnlyUseCase, searchVersesUseCase, getSurahVersesUseCase, repo, appState, previous) => previous ?? QuranProvider(
             getSurahsUseCase: getSurahsUseCase,
             getSurahsArabicOnlyUseCase: getSurahsArabicOnlyUseCase,
             searchVersesUseCase: searchVersesUseCase,
             getSurahVersesUseCase: getSurahVersesUseCase,
             quranRepository: repo,
+            appStateProvider: appState,
           ),
         ),
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -234,7 +234,7 @@ class KuraniFisnikApp extends StatelessWidget {
           create: (ctx) => AppStateProvider(getSettingsUseCase: Provider.of<GetSettingsUseCase>(ctx, listen: false), saveSettingsUseCase: Provider.of<SaveSettingsUseCase>(ctx, listen: false)),
           update: (_, getSettingsUseCase, saveSettingsUseCase, previous) => previous ?? AppStateProvider(getSettingsUseCase: getSettingsUseCase, saveSettingsUseCase: saveSettingsUseCase),
         ),
-  ChangeNotifierProxyProvider5<GetSurahsUseCase, GetSurahsArabicOnlyUseCase, SearchVersesUseCase, get_verses.GetSurahVersesUseCase, QuranRepositoryImpl, QuranProvider>(
+        ChangeNotifierProxyProvider5<GetSurahsUseCase, GetSurahsArabicOnlyUseCase, SearchVersesUseCase, get_verses.GetSurahVersesUseCase, QuranRepositoryImpl, QuranProvider>(
           create: (ctx) => QuranProvider(
             getSurahsUseCase: Provider.of<GetSurahsUseCase>(ctx, listen:false),
             getSurahsArabicOnlyUseCase: Provider.of<GetSurahsArabicOnlyUseCase>(ctx, listen:false),
@@ -242,7 +242,7 @@ class KuraniFisnikApp extends StatelessWidget {
             getSurahVersesUseCase: Provider.of<get_verses.GetSurahVersesUseCase>(ctx, listen:false),
             quranRepository: Provider.of<QuranRepositoryImpl>(ctx, listen:false),
           ),
-          update: (ctx, getSurahsUseCase, getSurahsArabicOnlyUseCase, searchVersesUseCase, getSurahVersesUseCase, repo, previous) => QuranProvider(
+          update: (ctx, getSurahsUseCase, getSurahsArabicOnlyUseCase, searchVersesUseCase, getSurahVersesUseCase, repo, previous) => previous ?? QuranProvider(
             getSurahsUseCase: getSurahsUseCase,
             getSurahsArabicOnlyUseCase: getSurahsArabicOnlyUseCase,
             searchVersesUseCase: searchVersesUseCase,

--- a/lib/presentation/providers/quran_provider.dart
+++ b/lib/presentation/providers/quran_provider.dart
@@ -246,6 +246,11 @@ class QuranProvider extends ChangeNotifier {
         includeArabic: _filterArabic,
         includeTransliteration: _filterTransliteration,
   ));
+      assert(() {
+        // ignore: avoid_print
+        print('[SearchDBG] Provider.searchVerses results=${_searchResults.length} query="$query"');
+        return true;
+      }());
       _error = null;
       notifyListeners();
       return;

--- a/lib/presentation/providers/quran_provider.dart
+++ b/lib/presentation/providers/quran_provider.dart
@@ -13,6 +13,7 @@ import 'search_index_manager.dart';
 import 'package:kurani_fisnik_app/core/utils/logger.dart';
 import '../../domain/repositories/quran_repository.dart';
 import '../../core/metrics/perf_metrics.dart';
+import 'app_state_provider.dart';
 
 class QuranProvider extends ChangeNotifier {
   final GetSurahsUseCase? _getSurahsUseCase;
@@ -34,6 +35,7 @@ class QuranProvider extends ChangeNotifier {
     required SearchVersesUseCase searchVersesUseCase,
     required GetSurahVersesUseCase getSurahVersesUseCase,
     QuranRepository? quranRepository,
+    AppStateProvider? appStateProvider,
   })  : _getSurahsUseCase = getSurahsUseCase,
         _getSurahsArabicOnlyUseCase = getSurahsArabicOnlyUseCase,
         _searchVersesUseCase = searchVersesUseCase,
@@ -66,6 +68,37 @@ class QuranProvider extends ChangeNotifier {
         notifyListeners();
       }
     });
+    // Track selected translation; refresh open surah when it changes
+    _selectedTranslationKey = appStateProvider?.selectedTranslation ?? _selectedTranslationKey;
+    _appStateListener = () {
+      final newKey = appStateProvider?.selectedTranslation ?? _selectedTranslationKey;
+      if (newKey != _selectedTranslationKey) {
+        _selectedTranslationKey = newKey;
+        // Inform repository of preferred key
+        _quranRepository?.setPreferredTranslationKey(newKey);
+        // If a surah is open and translations are shown, ensure enrichment and reload
+        final sid = _currentSurahId;
+        if (sid != null && _filterTranslation) {
+          // ignore: unawaited_futures
+          Future(() async {
+            try {
+              await _quranRepository?.ensureSurahTranslation(sid, translationKey: newKey);
+              // Reload verses to merge new translation
+              final enriched = await (_getSurahVersesUseCase?.call(sid) ?? Future.value(<Verse>[]));
+              if (enriched.isNotEmpty) {
+                _allCurrentSurahVerses = enriched;
+                // Reset pagination to reflect new text
+                _loadedVerseCount = 0;
+                _pagedVerses = [];
+                _appendMoreVerses();
+                notifyListeners();
+              }
+            } catch (_) {}
+          });
+        }
+      }
+    };
+    appStateProvider?.addListener(_appStateListener!);
   }
 
   // Simplified constructor for basic functionality without use cases
@@ -114,6 +147,9 @@ class QuranProvider extends ChangeNotifier {
   static const _debounceDuration = Duration(milliseconds: 350);
   bool _userTriggeredIndexOnce = false; // suppress duplicate logs
   String _lastQuery = '';
+  // Track preferred translation key from settings
+  String _selectedTranslationKey = 'sq_ahmeti';
+  VoidCallback? _appStateListener;
 
   List<SurahMeta> get surahs => _surahsMeta;
   List<Verse> get currentVerses => _pagedVerses;
@@ -311,54 +347,30 @@ class QuranProvider extends ChangeNotifier {
           _allCurrentSurahVerses = await uc.call(surahId);
         }
       }
-  Logger.d('Loaded verses surah=$surahId count=${_allCurrentSurahVerses.length}', tag: 'LazySurah');
-  // Attempt on-demand enrichment (translation + transliteration) asynchronously without blocking UI.
-      // We resolve repository via context-less global if needed; better would be dependency injection; skipping for brevity.
-      // ignore: unawaited_futures
-  final repo = _quranRepository;
-  if (repo != null) {
-        // Fire-and-forget enrichment: translation then transliteration.
-        Future(() async {
-          try {
-            // Respect current field filters: only enrich what’s needed.
-            final needT = _filterTranslation && !repo.isSurahFullyEnriched(surahId);
-            if (needT) {
-              await repo.ensureSurahTranslation(surahId);
-              Logger.d('Surah $surahId translation enriched', tag: 'LazySurah');
-            }
-            final needTr = _filterTransliteration && !repo.isSurahFullyEnriched(surahId);
-            if (needTr) {
-              await repo.ensureSurahTransliteration(surahId);
-              Logger.d('Surah $surahId transliteration enriched', tag: 'LazySurah');
-            }
-            // After enrichment, re-fetch the current surah verses once to merge enriched fields,
-            // then re-apply pagination without jank.
-            if (needT || needTr) {
-              try {
-                final enriched = await (_getSurahVersesUseCase?.call(surahId) ?? Future.value(<Verse>[]));
-                // Replace only if we are still on the same surah
-                if (_currentSurahId == surahId && enriched.isNotEmpty) {
-                  _allCurrentSurahVerses = enriched;
-                  // Recreate paged window preserving the already loaded count
-                  final prevLoaded = _loadedVerseCount;
-                  _pagedVerses = [];
-                  _loadedVerseCount = 0;
-                  _hasMoreVerses = false;
-                  while (_loadedVerseCount < prevLoaded && _loadedVerseCount < _allCurrentSurahVerses.length) {
-                    _appendMoreVerses();
-                  }
-                  // If nothing loaded yet, publish first page
-                  if (prevLoaded == 0 && _pagedVerses.isEmpty) {
-                    _appendMoreVerses();
-                  }
-                }
-              } catch (_) {}
-              notifyListeners();
-            }
-          } catch (e) {
-            Logger.w('Enrichment failed surah=$surahId err=$e', tag: 'LazySurah');
+      Logger.d('Loaded verses surah=$surahId count=${_allCurrentSurahVerses.length}', tag: 'LazySurah');
+      // Enrich synchronously before publishing to UI so translations/transliterations are present.
+      final repo = _quranRepository;
+      if (repo != null) {
+        try {
+          final needT = _filterTranslation && !repo.isSurahFullyEnriched(surahId);
+          final needTr = _filterTransliteration && !repo.isSurahFullyEnriched(surahId);
+          if (needT) {
+            await repo.ensureSurahTranslation(surahId, translationKey: _selectedTranslationKey);
+            Logger.d('Surah $surahId translation enriched', tag: 'LazySurah');
           }
-        });
+          if (needTr) {
+            await repo.ensureSurahTransliteration(surahId);
+            Logger.d('Surah $surahId transliteration enriched', tag: 'LazySurah');
+          }
+          if (needT || needTr) {
+            final enriched = await (_getSurahVersesUseCase?.call(surahId) ?? Future.value(<Verse>[]));
+            if (enriched.isNotEmpty) {
+              _allCurrentSurahVerses = enriched;
+            }
+          }
+        } catch (e) {
+          Logger.w('Synchronous enrichment failed surah=$surahId err=$e', tag: 'LazySurah');
+        }
       }
   _currentSurahId = surahId;
   // Preserve existing meta fields in _currentSurah (already set in navigateToSurah) and just attach verses after pagination.
@@ -548,6 +560,7 @@ class QuranProvider extends ChangeNotifier {
   _resultsRefreshDebounce?.cancel();
     _indexProgressSub?.cancel();
     _indexManager?.dispose();
+  _appStateListener = null; // owner (AppStateProvider) outlives this provider
     super.dispose();
   }
 

--- a/lib/presentation/providers/quran_provider.dart
+++ b/lib/presentation/providers/quran_provider.dart
@@ -222,6 +222,21 @@ class QuranProvider extends ChangeNotifier {
   bool get filterArabic => _filterArabic;
   bool get filterTransliteration => _filterTransliteration;
 
+  // Expose search index manager readiness (for UI gating and diagnostics)
+  bool get isSearchIndexReady => _indexManager?.isBuilt ?? false;
+
+  // Force-load full search index (prebuilt asset or snapshot or full build) – returns when ready.
+  Future<void> ensureSearchIndexReady() async {
+    final mgr = _indexManager;
+    if (mgr == null) return;
+    if (mgr.isBuilt) return;
+    try {
+      await mgr.ensureBuilt();
+    } catch (e) {
+      Logger.w('ensureSearchIndexReady failed: $e', tag: 'SearchIndex');
+    }
+  }
+
   Future<void> searchVerses(String query) async {
     _lastQuery = query.trim();
     if (query.trim().isEmpty) {

--- a/lib/presentation/providers/search_index_isolate.dart
+++ b/lib/presentation/providers/search_index_isolate.dart
@@ -2,6 +2,33 @@ import 'dart:convert';
 import 'inverted_index_builder.dart' as idx;
 import 'package:flutter/services.dart';
 
+/// Parse a prebuilt search snapshot JSON string into typed maps.
+/// Expected JSON shape:
+/// {
+///   "index": { "token": ["1:1", "1:2", ...], ... },
+///   "verses": { "1:1": {"surahNumber":1, "number":1, "verseKey":"1:1", "ar":"...", "t":"...", "tr":"...", "juz":1}, ... }
+/// }
+Map<String, dynamic> parsePrebuiltSearchSnapshot(String jsonStr) {
+  final obj = json.decode(jsonStr) as Map<String, dynamic>;
+  final idxAny = (obj['index'] as Map?) ?? const <String, dynamic>{};
+  final versesAny = (obj['verses'] as Map?) ?? const <String, dynamic>{};
+  final index = <String, List<String>>{};
+  idxAny.forEach((k, v) {
+    final key = k.toString();
+    if (v is List) {
+      index[key] = v.map((e) => e.toString()).toList(growable: false);
+    }
+  });
+  final verses = <String, Map<String, dynamic>>{};
+  versesAny.forEach((k, v) {
+    final key = k.toString();
+    if (v is Map) {
+      verses[key] = v.cast<String, dynamic>();
+    }
+  });
+  return {'index': index, 'verses': verses};
+}
+
 /// Payload keys expected by [buildFullIndexFromAssets]
 /// - 'arabic': JSON string of assets/data/arabic_quran.json
 /// - 'translation': JSON string of assets/data/<translation>.json (e.g., sq_ahmeti.json)

--- a/lib/presentation/providers/search_index_manager.dart
+++ b/lib/presentation/providers/search_index_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart' show compute;
+import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:flutter/services.dart' show rootBundle, ServicesBinding;
 import '../../domain/entities/verse.dart';
 import '../../domain/usecases/get_surah_verses_usecase.dart';
@@ -59,6 +60,17 @@ class SearchIndexManager {
     bool enablePrebuiltAsset = true,
   }) : _snapshotStore = snapshotStore ?? DefaultSnapshotStore(fileName: _snapshotFile),
         _enablePrebuiltAsset = enablePrebuiltAsset;
+
+  /// Test-only: inject a tiny index and verse cache to validate search behavior without building.
+  @visibleForTesting
+  void debugSetIndex(Map<String, List<String>> index, Map<String, Verse> verses) {
+    _invertedIndex = index;
+    _verseCache
+      ..clear()
+      ..addAll(verses);
+    _nextSurahToIndex = 115;
+    _incrementalMode = false;
+  }
 
   Future<bool> _tryLoadPrebuiltAsset() async {
     // Expect optional asset at assets/data/search_index.json containing keys: index, verses

--- a/lib/presentation/providers/search_index_manager.dart
+++ b/lib/presentation/providers/search_index_manager.dart
@@ -318,10 +318,10 @@ class SearchIndexManager {
       }
     }
     if (candidateScores.isEmpty) return [];
-  // Use normalized tokens for consistent matching/highlighting
-  final fullTokens = tq.tokenizeLatin(query)
-      .map((e) => e.toLowerCase())
-      .map(_normalizeLatin)
+  // Use expanded (normalized + stem) tokens for substring gating to avoid over-pruning
+  final fullTokens = tq
+      .expandQueryTokens(query, lightStem)
+      .map((e) => _normalizeLatin(e.toLowerCase()))
       .toSet();
   final scored = <_ScoredVerse>[];
     candidateScores.forEach((key, base) {

--- a/lib/presentation/providers/search_snapshot_store.dart
+++ b/lib/presentation/providers/search_snapshot_store.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:flutter/foundation.dart' show compute;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart';
 
@@ -33,7 +34,8 @@ class DefaultSnapshotStore implements SnapshotStore {
       final file = await _file();
       if (!await file.exists()) return null;
       final content = await file.readAsString();
-      return json.decode(content) as Map<String, dynamic>;
+  // Parse large JSON in an isolate to keep UI thread responsive
+  return await compute(_decodeJsonMap, content);
     } catch (_) {
       return null;
     }
@@ -89,3 +91,6 @@ class DefaultSnapshotStore implements SnapshotStore {
     }
   }
 }
+
+// Top-level function required for compute()
+Map<String, dynamic> _decodeJsonMap(String content) => json.decode(content) as Map<String, dynamic>;

--- a/lib/presentation/startup/startup_scheduler.dart
+++ b/lib/presentation/startup/startup_scheduler.dart
@@ -3,21 +3,19 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import '../providers/quran_provider.dart';
 import 'package:kurani_fisnik_app/core/utils/logger.dart';
-import '../providers/app_state_provider.dart';
 // Unused heavy providers removed from startup scheduler imports to reduce load.
 
 /// Lightweight phased startup coordinator to reduce main-isolate burst load.
 /// Phases (relative to first frame):
 ///  - Phase 1 (Frame 0): UI shell only (nothing here, just construction)
 ///  - Phase 2 (~+200ms): Load surah metadata (QuranProvider.loadSurahs)
-///  - Phase 3 (~+700ms): Resume / start search index incremental build
+///  - Phase 3: REMOVED (no search index work at startup to avoid jank)
 ///  - Phase 4 (~+1200ms): Warm minor providers (word-by-word ensure minimal) / optional translation prewarm placeholder
-/// All delays are adaptive: if user initiates a search early, we accelerate index phase.
+/// All delays are adaptive. Search index build is now triggered lazily when the user opens the Search tab.
 class StartupScheduler {
   final BuildContext context;
   bool _started = false;
   Timer? _phase2Timer;
-  Timer? _phase3Timer; // may be disabled if background indexing off
   Timer? _phase4Timer;
 
   StartupScheduler(this.context);
@@ -26,21 +24,22 @@ class StartupScheduler {
     if (_started) return;
     _started = true;
     // Schedule phases using timers so we don't block first frame.
-  _phase2Timer = Timer(const Duration(milliseconds: 200), () { Logger.d('Phase2 start', tag: 'StartupPhase'); _phase2(); Logger.d('Phase2 end', tag: 'StartupPhase');});
-  // Only schedule phase3 (index build consideration) if background indexing is currently enabled in settings at startup.
-  final app = context.read<AppStateProvider>();
-  if (app.backgroundIndexingEnabled) {
-    _phase3Timer = Timer(const Duration(milliseconds: 700), () { Logger.d('Phase3 start', tag: 'StartupPhase'); _phase3(); Logger.d('Phase3 end', tag: 'StartupPhase');});
-  }
-  _phase4Timer = Timer(const Duration(milliseconds: 1200), () { Logger.d('Phase4 start', tag: 'StartupPhase'); _phase4(); Logger.d('Phase4 end', tag: 'StartupPhase');});
+    _phase2Timer = Timer(const Duration(milliseconds: 200), () {
+      Logger.d('Phase2 start', tag: 'StartupPhase');
+      _phase2();
+      Logger.d('Phase2 end', tag: 'StartupPhase');
+    });
+    // Phase 3 intentionally not scheduled to avoid any search index work at startup.
+    _phase4Timer = Timer(const Duration(milliseconds: 1200), () {
+      Logger.d('Phase4 start', tag: 'StartupPhase');
+      _phase4();
+      Logger.d('Phase4 end', tag: 'StartupPhase');
+    });
   }
 
   void accelerateIndexBuild() {
     if (!_started) return;
-    if (_phase3Timer?.isActive ?? false) {
-      _phase3Timer!.cancel();
-      _phase3();
-    }
+    // No-op: search index build is lazily triggered by the Search tab itself.
   }
 
   void _phase2() {
@@ -50,20 +49,6 @@ class StartupScheduler {
     }
   }
 
-  void _phase3() {
-    // Try loading a snapshot or prebuilt index cheaply; if present, this is fast and avoids heavy CPU.
-    // This keeps startup light (no verse allocations), but primes search so it's usable immediately.
-    unawaited(() async {
-      try {
-        final q = context.read<QuranProvider>();
-        if (!q.isSearchIndexReady) {
-          await q.ensureSearchIndexReady();
-          Logger.d('Search index ensured (snapshot/prebuilt) in Phase 3', tag: 'StartupPhase');
-        }
-      } catch (_) {}
-    }());
-  }
-
   void _phase4() {
   // Light warmups only; heavy Hive warmups removed (large assets now in-memory cached on demand).
   // Keep hook here for future minor prewarms if needed.
@@ -71,7 +56,6 @@ class StartupScheduler {
 
   void dispose() {
     _phase2Timer?.cancel();
-    _phase3Timer?.cancel();
     _phase4Timer?.cancel();
   }
 }

--- a/test/asset_guard_test.dart
+++ b/test/asset_guard_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('search_index.json exists and has a non-empty index', () async {
+    final f = File('assets/data/search_index.json');
+    expect(await f.exists(), isTrue, reason: 'search_index.json missing');
+    final size = await f.length();
+    expect(size, greaterThan(1024), reason: 'search_index.json looks empty');
+    final map = json.decode(await f.readAsString()) as Map<String, dynamic>;
+    expect(map['index'], isA<Map>());
+    expect((map['index'] as Map).isNotEmpty, isTrue);
+  });
+}

--- a/test/quran_provider_navigation_test.dart
+++ b/test/quran_provider_navigation_test.dart
@@ -75,6 +75,8 @@ class _FakeQuranRepo implements QuranRepository {
   Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
   @override
   Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
 }
 
 void main() {

--- a/test/search_index_progress_test.dart
+++ b/test/search_index_progress_test.dart
@@ -44,6 +44,8 @@ class _FakeRepo implements QuranRepository {
   Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
   @override
   Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
 }
 
 void main() {

--- a/test/search_meshire_gating_test.dart
+++ b/test/search_meshire_gating_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kurani_fisnik_app/presentation/providers/search_index_manager.dart';
+import 'package:kurani_fisnik_app/domain/usecases/get_surahs_usecase.dart';
+import 'package:kurani_fisnik_app/domain/usecases/get_surah_verses_usecase.dart';
+import 'package:kurani_fisnik_app/domain/entities/verse.dart';
+import 'package:kurani_fisnik_app/domain/entities/surah.dart';
+import 'package:kurani_fisnik_app/domain/repositories/quran_repository.dart';
+import 'package:kurani_fisnik_app/domain/entities/surah_meta.dart';
+
+class _FakeRepo implements QuranRepository {
+  @override
+  Future<List<Surah>> getAllSurahs() async => [Surah(id:1, number:1, nameArabic:'', nameTranslation:'', nameTransliteration:'', revelation:'', versesCount:7, verses:const [])];
+  @override
+  Future<Surah> getSurah(int surahNumber) async => (await getAllSurahs()).first;
+  @override
+  Future<List<Verse>> getSurahVerses(int surahNumber) async => [
+    Verse(surahId: surahNumber, verseNumber: 1, arabicText: 'الرَّحْمَٰنِ الرَّحِيمِ', translation: 'Mëshiruesi, Mëshirëbërësi', transliteration: 'ar-rahman ar-rahim', verseKey: '$surahNumber:1'),
+  ];
+  @override
+  Future<Verse> getVerse(int surahNumber, int verseNumber) async => (await getSurahVerses(surahNumber)).firstWhere((v)=>v.verseNumber==verseNumber);
+  @override
+  Future<List<Verse>> getVersesBySurah(int surahId) async => getSurahVerses(surahId);
+  @override
+  Future<Map<String, dynamic>> getTranslation(String translationKey) async => {};
+  @override
+  Future<Map<String, dynamic>> getThematicIndex() async => {};
+  @override
+  Future<Map<String, dynamic>> getTransliterations() async => {};
+  @override
+  Future<List<SurahMeta>> getSurahList() async => (await getAllSurahs()).map(SurahMeta.fromSurah).toList();
+  @override
+  Future<List<Verse>> getVersesForSurah(int surahId) async => getSurahVerses(surahId);
+  @override
+  Future<List<Verse>> searchVerses(String query, {String? translationKey}) async => [];
+  @override
+  Future<void> ensureSurahTranslation(int surahNumber, {String translationKey = 'sq_ahmeti'}) async {}
+  @override
+  Future<void> ensureSurahTransliteration(int surahNumber) async {}
+  @override
+  bool isSurahFullyEnriched(int surahNumber) => true;
+  @override
+  Map<String, double> translationCoverageByKey() => const {};
+  @override
+  Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
+  @override
+  Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+}
+
+void main() {
+  test('search finds results for meshire variants via normalized+stem gating', () async {
+    final repo = _FakeRepo();
+    final mgr = SearchIndexManager(
+      getSurahsUseCase: GetSurahsUseCase(repo),
+      getSurahVersesUseCase: GetSurahVersesUseCase(repo),
+    );
+    // Inject minimal index and verse cache
+    mgr.debugSetIndex({
+      // tokens likely to exist after index build (normalized):
+      'meshire': ['1:1'], 'meshireberes': ['1:1'], 'ar': ['1:1'], 'rahman': ['1:1'], 'rahim': ['1:1']
+    }, {
+      '1:1': Verse(
+        surahId: 1,
+        verseNumber: 1,
+        arabicText: 'الرَّحْمَٰنِ الرَّحِيمِ',
+        translation: 'Mëshiruesi, Mëshirëbërësi',
+        transliteration: 'ar-rahman ar-rahim',
+        verseKey: '1:1',
+      )
+    });
+
+    final res1 = mgr.search('meshire');
+    final res2 = mgr.search('mëshirë');
+    final res3 = mgr.search('meshireberes');
+
+    expect(res1.map((v)=>v.verseKey), contains('1:1'));
+    expect(res2.map((v)=>v.verseKey), contains('1:1'));
+    expect(res3.map((v)=>v.verseKey), contains('1:1'));
+  });
+}

--- a/test/search_meshire_gating_test.dart
+++ b/test/search_meshire_gating_test.dart
@@ -44,6 +44,8 @@ class _FakeRepo implements QuranRepository {
   Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
   @override
   Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
 }
 
 void main() {

--- a/test/search_snapshot_invalidation_test.dart
+++ b/test/search_snapshot_invalidation_test.dart
@@ -92,4 +92,6 @@ class _DummyRepo implements QuranRepository {
   Future<List<SurahMeta>> getSurahList() async => [];
   @override
   Future<List<Verse>> getVersesForSurah(int surahId) async => [];
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
 }

--- a/test/search_tab_crash_test.dart
+++ b/test/search_tab_crash_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+
+// Placeholder regression test for the intermittent Search tab crash (#4).
+// Skipped for now due to environment flakiness with compact reporter and
+// the need for a fuller provider scaffold. This will be enabled in the PR
+// once we land a stable harness around SearchWidget.
+
+void main() {
+  testWidgets(
+    '[SKIPPED] Search tab opens and typing does not crash',
+    (tester) async {
+      // TODO: Implement a stable harness with providers and SearchWidget,
+      // reproduce rapid typing + filter toggles, assert no exceptions.
+    },
+    skip: true,
+  );
+}

--- a/test/unit/get_surahs_usecase_test.dart
+++ b/test/unit/get_surahs_usecase_test.dart
@@ -51,6 +51,8 @@ class FakeQuranRepository implements QuranRepository {
   Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
   @override
   Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
 }
 
 void main() {

--- a/test/unit/search_verses_usecase_test.dart
+++ b/test/unit/search_verses_usecase_test.dart
@@ -51,6 +51,8 @@ class FakeQuranRepository implements QuranRepository {
   Stream<double> get enrichmentCoverageStream => const Stream<double>.empty();
   @override
   Stream<Map<String, double>> get translationCoverageStream => const Stream<Map<String, double>>.empty();
+  @override
+  void setPreferredTranslationKey(String translationKey) {}
   // Duplicate signature for searchVerses with Surah return removed
 }
 

--- a/tool/validate_assets.dart
+++ b/tool/validate_assets.dart
@@ -1,0 +1,31 @@
+// Validates that critical assets exist and are non-empty.
+// Usage: dart run tool/validate_assets.dart
+import 'dart:convert';
+import 'dart:io';
+
+Never _fail(String msg) {
+  stderr.writeln('ASSET VALIDATION FAILED: $msg');
+  exit(2);
+}
+
+void main(List<String> args) async {
+  final indexFile = File('assets/data/search_index.json');
+  if (!indexFile.existsSync()) {
+    _fail('assets/data/search_index.json is missing. Run tool/build_search_index.dart');
+  }
+  final len = await indexFile.length();
+  if (len < 1024) {
+    _fail('assets/data/search_index.json is too small ($len bytes) — appears empty/corrupt.');
+  }
+  try {
+    final content = await indexFile.readAsString();
+    final jsonMap = json.decode(content) as Map<String, dynamic>;
+    final index = jsonMap['index'];
+    if (index is! Map || index.isEmpty) {
+      _fail('search_index.json has no "index" map or it is empty.');
+    }
+  } catch (e) {
+    _fail('Failed to parse search_index.json: $e');
+  }
+  stdout.writeln('Assets OK: search_index.json present and non-empty.');
+}


### PR DESCRIPTION
This PR fixes the search regression and adds guardrails:

- Generate and include a valid prebuilt search index asset (`assets/data/search_index.json`), fixing invSize=0.
- Ensure the Search tab loads the index at startup and awaits readiness before queries, then continues with incremental builds safely.
- Add an asset validation tool and a guard test to catch empty/corrupt index.
- Consolidate CI workflow to build+validate the index, analyze, and run tests.
- Clean up a `use_build_context_synchronously` warning by capturing values before awaiting.

Verification:
- Local run shows invSize31k and results for representative queries.
- `flutter test` passes including new guard.
- `flutter analyze` clean of critical issues.

Follow-ups (nice-to-have):
- Profile and reduce initial skipped frames; consider lazy hydration of heavy providers.